### PR TITLE
Make it easier to use imapdedup.py as a Python module

### DIFF
--- a/imapdedup.py
+++ b/imapdedup.py
@@ -128,9 +128,7 @@ def print_message_info(parsed_message):
     print("")
 
 # This actually does the work
-def main(args):
-    options, mboxes = get_arguments(args)
-
+def process(options, mboxes):
     if options.ssl:
         serverclass = imaplib.IMAP4_SSL
     else:
@@ -266,6 +264,9 @@ def main(args):
     finally:
         server.logout()
 
+def main(args):
+    options, mboxes = get_arguments(args)
+    process(options, mboxes)
 
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
Thanks for writing this!

These changes make it easy to start the deduplification in an automated way (e.g., from a cron job) via a short file that can be as simple as:

```
import imapdedup

class options:
    server = 'imap.example.com'
    port = None
    ssl = True
    user = 'me'
    password = 'Pa$$w0rd'
    verbose = False
    dry_run = False
    use_checksum = False
    use_id_in_checksum = False
    just_list = False

mboxes = [
    'INBOX',
    'Some other mailbox',
    ]

imapdedup.process(options, mboxes)
```

This, in turn, is nice because it doesn't require a password to be passed to the program via a command-line argument, where it could be seen by other users of the system.  (This short startup file could be made read-only.)
