### PR TITLE
Add no-close option to leave deleted messages

### DIFF
--- a/imapdedup.py
+++ b/imapdedup.py
@@ -214,7 +214,11 @@ def process(options, mboxes):
 
                     # Record the message-ID header (or generate one from other headers)
                     msg_id = get_message_id(mp, options.use_checksum, options.use_id_in_checksum)
-                    msg_map[mnum] = mp
+
+                    # Store message only when verbose is enabled (to print it later on)
+                    if options.verbose:
+                        msg_map[mnum] = mp
+
                     if msg_id:
                         # If we've seen this message before, record it as one to be
                         # deleted in this mailbox.


### PR DESCRIPTION
On a dovecot server, the messages get deleted when imapdedup calls
close. However, in order to review the delete flags on a mail client
it is convenient to have them just flagged, so the user can expunge
them manually.

Also storing the parsed messages needs a lot of memory, and we need
it only for verbose mode. Hence make storing them conditional.
