### PR TITLE
Avoid IndexError (list index out of range)

### DIFF
--- a/imapdedup.py
+++ b/imapdedup.py
@@ -251,7 +251,7 @@ def process(options, mboxes):
 
                 # and parse them.
                 for ci in range(0, len(ms)/2):
-                    mnum = msgnums_in_chunk[ci]
+                    mnum = ms[ci * 2][0].split()[0]
                     mp = p.parsestr(ms[ci * 2][1])
                     if options.verbose:
                         print("Checking %s message %s" % (mbox, mnum))

--- a/imapdedup.py
+++ b/imapdedup.py
@@ -250,7 +250,7 @@ def process(options, mboxes):
                     print ("Batch starting at item %d" % i)
 
                 # and parse them.
-                for ci in range(0, len(msgnums_in_chunk)):
+                for ci in range(0, len(ms)/2):
                     mnum = msgnums_in_chunk[ci]
                     mp = p.parsestr(ms[ci * 2][1])
                     if options.verbose:


### PR DESCRIPTION
There are possibles scenarios when the IMAP server provide a response that does not contain the result for all FETCH commands. For such cases we could adapt the code to take into consideration only the results presented by server.