### PR TITLE
Add an option to make STARTTLS mandatory

### DIFF
--- a/imapdedup.py
+++ b/imapdedup.py
@@ -70,6 +70,7 @@ def get_arguments(args: List[str]) -> Tuple[optparse.Values, List[str]]:
     parser.add_option("-s", "--server", dest="server", help="IMAP server")
     parser.add_option("-p", "--port", dest="port", help="IMAP server port", type="int")
     parser.add_option("-x", "--ssl", dest="ssl", action="store_true", help="Use SSL")
+    parser.add_option("-X", "--starttls", dest="starttls", action="store_true", help="Require STARTTLS")
     parser.add_option("-u", "--user", dest="user", help="IMAP user name")
     parser.add_option(
         "-w",
@@ -328,6 +329,9 @@ def process(options, mboxes: List[str]):
 
     if ("STARTTLS" in server.capabilities) and hasattr(server, "starttls"):
         server.starttls()
+    elif options.starttls:
+        sys.stderr.write("\nError: Server did not offer TLS\n")
+        sys.exit(1)
     elif not options.ssl:
         sys.stderr.write("\nWarning: Unencrypted connection\n")
 


### PR DESCRIPTION
Some IMAP servers (mail providers) make secure connections only
available via STARTTLS but not via separate-port TLS.

However, the current "opportunistic" implementation is susceptible to
downgrade attacks, that is, a client can be fooled into thinking the
server doesn't support it – and will happily continue with the rest of
the connection in plaintext.

Adding this option allows STARTTLS mode to provide the same level of
security (resilience to downgrade attacks) as TLS on separate port does.