### PR TITLE
Fixed msg_id parsing when header indentated

### DIFF
--- a/imapdedup.py
+++ b/imapdedup.py
@@ -240,7 +240,7 @@ def get_message_id(
             update(("Cc:" + str_header(parsed_message, "Cc")).encode())
             update(("Bcc:" + str_header(parsed_message, "Bcc")).encode())
             if options_use_id_in_checksum:
-                update(("Message-ID:" + str_header(parsed_message, "Message-ID")).encode())
+                update(("Message-ID:" + str_header(parsed_message, "Message-ID").lstrip()).encode()) #Strip any whitespace left of the string, i.e. when the id is indentated with \n\t
             msg_id = md5.hexdigest() + "|" + sha.hexdigest() + "|" + sha3.hexdigest()
             # print(msg_id)
         else:
@@ -257,7 +257,7 @@ def get_message_id(
                 )
                 print("You might want to use the -c option.")
                 return None
-        return msg_id
+        return msg_id.lstrip() #Strip any whitespace left of the string, i.e. when the id is indentated with \n\t
     except (ValueError, HeaderParseError):
         print(
             "WARNING: There was an exception trying to parse the headers of this message."


### PR DESCRIPTION
Added `lstrip()` to the `get_message_id` return, to account for emails where the Message-Id header is like:
```
Message-ID: 
	<123456@host>
```
which would not match:
```
Message-ID: <123456@host>
```