### PR TITLE
Keyring: no value means server

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you don't wish to specify a password via a command-line argument, where it co
 * You can specify it in a wrapper script as described below, or
 * You can put it into your system's [keyring](https://pypi.org/project/keyring/).
 
-For the keyring option you'll need to pip install [keyring](https://pypi.org/project/keyring/). You can then use `-K` to specify a system keyring name that will be used to get the password for the account specified via option `-u`.
+For the keyring option you'll need to pip install [keyring](https://pypi.org/project/keyring/). You can then use `-K` to specify a system keyring name that will be used to get the password for the account specified via option `-u`.  If you just use `-K' without a value, the server name provided will be used as the keyring name.
 
 ## Authenticating as an admin user
 

--- a/imapdedup.py
+++ b/imapdedup.py
@@ -80,7 +80,14 @@ def get_arguments(args: Optional[List[str]] = None) -> Tuple[argparse.Namespace,
     parser.add_argument("-X", "--starttls", dest="starttls", action="store_true", help="Require STARTTLS")
     parser.add_argument("-u", "--user", dest="user", help="IMAP user name")
     parser.add_argument("-a", "--authuser", dest='authuser', help='IMAP admin user')
-    parser.add_argument("-K", "--keyring", dest="keyring", help="Keyring name to get password")
+    parser.add_argument(
+        "-K",
+        "--keyring",
+        dest="keyring",
+        nargs='?',
+        const='',
+        help="Keyring name to get password, no value means to use IMAP server name"
+    )
     parser.add_argument(
         "-w",
         "--password",
@@ -174,6 +181,9 @@ def get_arguments(args: Optional[List[str]] = None) -> Tuple[argparse.Namespace,
     if options.use_id_in_checksum and not options.use_checksum:
         sys.stderr.write("\nError: If you use -m you must also use -c.\n")
         sys.exit(1)
+
+    if options.keyring == '':
+        options.keyring = options.server
 
     if options.keyring:
         import keyring


### PR DESCRIPTION
Here a kind of simplification of using system keyring. Instead of:
```
imapdedup -s imappro.zoho.com -u kirill@korins.ky -K imappro.zoho.com -l -x 
```
it allows to call as:
```
imapdedup -s imappro.zoho.com -u kirill@korins.ky -K -l -x 
```
