### PR TITLE
added expunge feature  issue #67 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ If you have a hierarchy of folders, you can search recursively within the childr
 
 You can use the `-R` option to reverse the order in which the folders are processed.  The main use of this is with recursive searches, if you want duplicates of messages found in child folders to be removed from the parents, rather than the other way around.
 
+With the `-d` option, it's removes all marked messages from the server (Expunge).  This is a dangerous option, so use with caution!
+
 ## Specifying the password
 
 If you don't wish to specify a password via a command-line argument, where it could be seen by other users of the system, and you don't want to type it in each time, you have three options:


### PR DESCRIPTION
Added expunge feature to delete all messages on server.

I have tested this feature on a plesk server with over 35GB duplicates.
The expunge runs in a few seconds, and the deletion process runs on the server for ~10min.

To use the feature add `-d` or `--delete`.
