### PR TITLE
feat: Add Dockerfile for building and running image encapsulated in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# To build the image:
+#   docker build -t imapdedup .
+# To run the image:
+#   docker run -it --rm imapdedup --help
+FROM python:3.12-slim
+
+RUN python -m pip install hatch
+RUN mkdir /app
+
+WORKDIR /app
+
+COPY pyproject.toml /app
+
+RUN hatch dep show requirements > /app/requirements.txt && \
+    python -m pip install -r /app/requirements.txt
+
+COPY . /app
+
+ENTRYPOINT [ "hatch", "run", "imapdedup" ]
+CMD [ "--help" ]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ If you might want to modify the script yourself, I recommend using [uv](https://
 
 which will create a virtualenv for you and keep it up to date as you experiment without you having to think much about it or do any activation and deactivation.
 
+### Using docker
+
+To run IMAPdedup in a docker container, you can use the following commands:
+First, build the image:
+
+    docker build -t imapdedup .
+
+Then you can run the container with the following command:
+
+    docker run --rm -it imapdedup --help
+
+See _[Simple-use](#simple-use)_ for more information on how to use IMAPdedup.
 
 ## Trying it out
 


### PR DESCRIPTION
This change adds a `Dockerfile` for running imapdedup encapsulated in a container.

The following changes have been made:

- Introduces a Dockerfile to build an image with Python dependencies.
- Sets up the environment, installs packages, and configures entrypoint.
- Allows users to easily build and run the image for imapdedup tool.

To run IMAPdedup in a docker container, you can use the following commands:

# Usage

## Build the image

First, to build the container:

    docker build -t imapdedup .

## Run as container

Then you can run the container with the following command:

    docker run --rm -it imapdedup --help

