### PR TITLE
feat: Add Docker workflow for building, pushing & signing images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,104 @@
+name: Build & Push Docker Image
+
+on:
+  schedule:
+    - cron: '36 2 * * *'
+  push:
+    branches: [ "$default-branch", ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "$default-branch" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}},value=${{ github.ref }}
+            type=sha,value=${{ github.sha }}
+          flavor: |
+            latest=${{ github.event_name != 'pull_request' }}
+          labels: |
+            org.opencontainers.image.title=${{ github.repository }}
+            org.opencontainers.image.source="https://github.com/${{ github.repository }}"
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Note that IMAPdedup doesn't *need* any installation process, however, and doesn'
 
     python3 imapdedup.py ...
 
-If you might want to modify the script yourself, I recommend using [uv](https://docs.astral.sh/uv/). You can then simply get a copy of the source and use: 
+If you might want to modify the script yourself, I recommend using [uv](https://docs.astral.sh/uv/). You can then simply get a copy of the source and use:
 
     uv run imapdedup ....
 
@@ -48,11 +48,15 @@ which will create a virtualenv for you and keep it up to date as you experiment 
 To run IMAPdedup in a Docker container, you can use the following commands:
 First, build the image:
 
-    docker build -t imapdedup .
+    docker build -t ghcr.io/quentinsf/imapdedup:latest .
+
+Or pull an image from the GitHub Container Registry:
+
+    docker pull ghcr.io/quentinsf/imapdedup:latest
 
 Then you can run the container with the following command:
 
-    docker run --rm -it imapdedup --help
+    docker run --rm -it ghcr.io/quentinsf/imapdedup:latest --help
 
 See _[Simple-use](#simple-use)_ for more information on how to use IMAPdedup.
 
@@ -123,7 +127,7 @@ We don't curently have a way of storing your options in a configuration file, bu
     import imapdedup
 
     options = [
-        "-s", "imap.example.com", 
+        "-s", "imap.example.com",
         "-u", "my_user_name",
         "-w", "my_password",
         "-x"


### PR DESCRIPTION
This pull request includes significant updates to automate the Docker image building and pushing process using GitHub Actions, as well as updating the Docker commands in the `README.md` file.

Automation of Docker image building and pushing:

* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94R1-R104): Added a GitHub Actions workflow to build and push Docker images on a schedule, push to specific branches and tags, and handle pull requests. The workflow includes steps for setting up QEMU, installing cosign, setting up Docker Buildx, logging into the registry, extracting Docker metadata, building and pushing the Docker image, and signing the Docker image digest.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R59): Updated the Docker commands to use the GitHub Container Registry (`ghcr.io`) instead of a local Docker image. This includes commands for building, pulling, and running the Docker image.